### PR TITLE
Nginx config to run Huly on one domain name

### DIFF
--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -165,6 +165,5 @@ networks:
 
 volumes:
   db:
-  letsencrypt:
   elastic:
   files:

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -1,0 +1,170 @@
+services:
+  nginx:
+    image: "nginx:1.21.3"
+    ports:
+      - "8080:80"
+    volumes:
+      - ./huly.nginx:/etc/nginx/conf.d/default.conf
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  mongodb:
+    image: "mongo:7-jammy"
+    container_name: mongodb
+    environment:
+      - PUID=1000
+      - PGID=1000
+    volumes:
+      - db:/data/db
+    restart: unless-stopped
+    networks:
+      - internal-services
+
+  elastic:
+    image: "elasticsearch:7.14.2"
+    command: |
+      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
+      /usr/local/bin/docker-entrypoint.sh eswrapper"
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
+    environment:
+      - ELASTICSEARCH_PORT_NUMBER=9200
+      - BITNAMI_DEBUG=true
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
+      - http.cors.enabled=true
+      - http.cors.allow-origin=http://localhost:8082
+    healthcheck:
+      interval: 20s
+      retries: 10
+      test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+    restart: unless-stopped
+    networks:
+      - internal-services
+
+  minio:
+    image: "minio/minio"
+    command: server /data --address ":9000" --console-address ":9001"
+    volumes:
+      - files:/data
+    restart: unless-stopped
+    networks:
+      - internal-services
+
+  rekoni:
+    image: hardcoreeng/rekoni-service:v0.6.245
+    environment:
+      - SECRET=c37fef1f157efe09785844215225ee3d1ab8086eb822055d5aa1bdedc72921bd
+    deploy:
+      resources:
+        limits:
+          memory: 500M
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  transactor:
+    image: hardcoreeng/transactor:v0.6.245
+    environment:
+      - SERVER_PORT=3333
+      - SERVER_SECRET=c37fef1f157efe09785844215225ee3d1ab8086eb822055d5aa1bdedc72921bd
+      - SERVER_CURSOR_MAXTIMEMS=30000
+      - ELASTIC_URL=http://elastic:9200
+      - ELASTIC_INDEX_NAME=huly_storage_index
+      - MONGO_URL=mongodb://mongodb:27017
+      - METRICS_CONSOLE=false
+      - METRICS_FILE=metrics.txt
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+      - REKONI_URL=http://rekoni:4004
+      - FRONT_URL=http://localhost:8087
+      - SERVER_PROVIDER=wss
+      - ACCOUNTS_URL=http://account:3000
+      - LAST_NAME_FIRST=true
+      - UPLOAD_URL=https://example.com/files
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+
+  collaborator:
+    image: hardcoreeng/collaborator:v0.6.245
+    environment:
+      - COLLABORATOR_PORT=3078
+      - SECRET=c37fef1f157efe09785844215225ee3d1ab8086eb822055d5aa1bdedc72921bd
+      - ACCOUNTS_URL=http://account:3000
+      - TRANSACTOR_URL=ws://transactor:3333
+      - UPLOAD_URL=/files
+      - MONGO_URL=mongodb://mongodb:27017
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  account:
+    image: hardcoreeng/account:v0.6.245
+    environment:
+      - SERVER_PORT=3000
+      - SERVER_SECRET=c37fef1f157efe09785844215225ee3d1ab8086eb822055d5aa1bdedc72921bd
+      - MONGO_URL=mongodb://mongodb:27017
+      - TRANSACTOR_URL=ws://transactor:3333
+      - ENDPOINT_URL=${wss}://example.com/_transactor # this is the transactor endpoint
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+      - FRONT_URL=http://front:8080
+      - INIT_WORKSPACE=demo-tracker
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=http://localhost:3000
+      - ACCOUNT_PORT=3000
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  front:
+    image: hardcoreeng/front:v0.6.245
+    environment:
+      - SERVER_PORT=8080
+      - SERVER_SECRET=c37fef1f157efe09785844215225ee3d1ab8086eb822055d5aa1bdedc72921bd
+      - ACCOUNTS_URL=https://example.com/_accounts
+      - REKONI_URL=https://example.com/_rekoni
+      - CALENDAR_URL=https://example.com:8095
+      - GMAIL_URL=https://example.com:8088
+      - TELEGRAM_URL=https://example.com:8086
+      - UPLOAD_URL=/files
+      - TRANSACTOR_URL=${wss}://example.com/_transactor
+      - ELASTIC_URL=http://elastic:9200
+      - COLLABORATOR_URL=${wss}://example.com/_collaborator
+      - COLLABORATOR_API_URL=https://example.com/_collaborator
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+      - MONGO_URL=mongodb://mongodb:27017
+      - TITLE=Huly Self Host
+      - DEFAULT_LANGUAGE=en
+      - LAST_NAME_FIRST=true
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+networks:
+  nginx-public:
+    name: nginx-public
+  internal-services:
+    name: internal-services
+
+volumes:
+  db:
+  letsencrypt:
+  elastic:
+  files:

--- a/nginx/huly.nginx
+++ b/nginx/huly.nginx
@@ -1,0 +1,69 @@
+server {
+    listen 80;
+    server_name _;
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://front:8080;
+    }
+
+    location /_accounts {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        rewrite ^/_accounts(/.*)$ $1 break;
+        proxy_pass http://account:3000/;
+    }
+
+    location /_collaborator {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        rewrite ^/_collaborator(/.*)$ $1 break;
+        proxy_pass http://collaborator:3078/;
+    }
+
+    location /_transactor {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        rewrite ^/_transactor(/.*)$ $1 break;
+        proxy_pass http://transactor:3333/;
+    }
+
+    location ~ ^/eyJ {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://transactor:3333;
+    }
+
+    location /_reconi {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        rewrite ^/_reconi(/.*)$ $1 break;
+        proxy_pass http://reconi:4004/;
+    }
+}

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Ask for the domain name
+read -p "Enter the domain name: " DOMAIN_NAME
+if [ -z "$DOMAIN_NAME" ]; then
+  echo "DOMAIN_NAME is required"
+  exit 1
+fi
+
+read -p "Enter the port you want nginx to expose: " NGINX_SERVICE_PORT
+if [ -z "$NGINX_SERVICE_PORT" ]; then
+  echo "NGINX_SERVICE_PORT address is required"
+  exit 1
+fi
+
+read -p "Do you run behind SSL proxy (did you setup HTTPS)? (Y/n): " NGINX_BEHIND_SSL
+case "$NGINX_BEHIND_SSL" in
+    [Yy]* )
+        NGINX_WS_SCHEME="wss"
+        NGINX_HTTP_SCHEME="https"
+        ;;
+    [Nn]* )
+        NGINX_WS_SCHEME="ws"
+        NGINX_HTTP_SCHEME="http"
+        ;;
+    * )
+        echo "SSL selected"
+        NGINX_WS_SCHEME="wss"
+        NGINX_HTTP_SCHEME="https"
+        ;;
+esac
+
+
+export HULY_VERSION="v0.6.245"
+export SERVER_ADDRESS=$DOMAIN_NAME
+export NGINX_SERVICE_PORT=$NGINX_SERVICE_PORT
+export NGINX_HTTP_SCHEME=$NGINX_HTTP_SCHEME
+export NGINX_WS_SCHEME=$NGINX_WS_SCHEME
+# $(openssl rand -hex 32)
+export HULY_SECRET="c37fef1f157efe09785844215225ee3d1ab8086eb822055d5aa1bdedc72921bd"
+
+# replace the domain name and email address in the docker-compose file
+envsubst < template-compose.yml > docker-compose.yml
+
+echo -e "\033[1;32mSetup is complete. Run 'docker compose up -d' to start the services.\033[0m"
+

--- a/nginx/template-compose.yml
+++ b/nginx/template-compose.yml
@@ -165,6 +165,5 @@ networks:
 
 volumes:
   db:
-  letsencrypt:
   elastic:
   files:

--- a/nginx/template-compose.yml
+++ b/nginx/template-compose.yml
@@ -1,0 +1,170 @@
+services:
+  nginx:
+    image: "nginx:1.21.3"
+    ports:
+      - "${NGINX_SERVICE_PORT}:80"
+    volumes:
+      - ./huly.nginx:/etc/nginx/conf.d/default.conf
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  mongodb:
+    image: "mongo:7-jammy"
+    container_name: mongodb
+    environment:
+      - PUID=1000
+      - PGID=1000
+    volumes:
+      - db:/data/db
+    restart: unless-stopped
+    networks:
+      - internal-services
+
+  elastic:
+    image: "elasticsearch:7.14.2"
+    command: |
+      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment || yes | ./bin/elasticsearch-plugin install --silent ingest-attachment;
+      /usr/local/bin/docker-entrypoint.sh eswrapper"
+    volumes:
+      - elastic:/usr/share/elasticsearch/data
+    environment:
+      - ELASTICSEARCH_PORT_NUMBER=9200
+      - BITNAMI_DEBUG=true
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms1024m -Xmx1024m
+      - http.cors.enabled=true
+      - http.cors.allow-origin=http://localhost:8082
+    healthcheck:
+      interval: 20s
+      retries: 10
+      test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+    restart: unless-stopped
+    networks:
+      - internal-services
+
+  minio:
+    image: "minio/minio"
+    command: server /data --address ":9000" --console-address ":9001"
+    volumes:
+      - files:/data
+    restart: unless-stopped
+    networks:
+      - internal-services
+
+  rekoni:
+    image: hardcoreeng/rekoni-service:${HULY_VERSION}
+    environment:
+      - SECRET=${HULY_SECRET}
+    deploy:
+      resources:
+        limits:
+          memory: 500M
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  transactor:
+    image: hardcoreeng/transactor:${HULY_VERSION}
+    environment:
+      - SERVER_PORT=3333
+      - SERVER_SECRET=${HULY_SECRET}
+      - SERVER_CURSOR_MAXTIMEMS=30000
+      - ELASTIC_URL=http://elastic:9200
+      - ELASTIC_INDEX_NAME=huly_storage_index
+      - MONGO_URL=mongodb://mongodb:27017
+      - METRICS_CONSOLE=false
+      - METRICS_FILE=metrics.txt
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+      - REKONI_URL=http://rekoni:4004
+      - FRONT_URL=http://localhost:8087
+      - SERVER_PROVIDER=wss
+      - ACCOUNTS_URL=http://account:3000
+      - LAST_NAME_FIRST=true
+      - UPLOAD_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}/files
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+
+  collaborator:
+    image: hardcoreeng/collaborator:${HULY_VERSION}
+    environment:
+      - COLLABORATOR_PORT=3078
+      - SECRET=${HULY_SECRET}
+      - ACCOUNTS_URL=http://account:3000
+      - TRANSACTOR_URL=ws://transactor:3333
+      - UPLOAD_URL=/files
+      - MONGO_URL=mongodb://mongodb:27017
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  account:
+    image: hardcoreeng/account:${HULY_VERSION}
+    environment:
+      - SERVER_PORT=3000
+      - SERVER_SECRET=${HULY_SECRET}
+      - MONGO_URL=mongodb://mongodb:27017
+      - TRANSACTOR_URL=ws://transactor:3333
+      - ENDPOINT_URL=${$NGINX_WS_SCHEME}://${SERVER_ADDRESS}/_transactor # this is the transactor endpoint
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+      - FRONT_URL=http://front:8080
+      - INIT_WORKSPACE=demo-tracker
+      - MODEL_ENABLED=*
+      - ACCOUNTS_URL=http://localhost:3000
+      - ACCOUNT_PORT=3000
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+  front:
+    image: hardcoreeng/front:${HULY_VERSION}
+    environment:
+      - SERVER_PORT=8080
+      - SERVER_SECRET=${HULY_SECRET}
+      - ACCOUNTS_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}/_accounts
+      - REKONI_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}/_rekoni
+      - CALENDAR_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}:8095
+      - GMAIL_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}:8088
+      - TELEGRAM_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}:8086
+      - UPLOAD_URL=/files
+      - TRANSACTOR_URL=${$NGINX_WS_SCHEME}://${SERVER_ADDRESS}/_transactor
+      - ELASTIC_URL=http://elastic:9200
+      - COLLABORATOR_URL=${$NGINX_WS_SCHEME}://${SERVER_ADDRESS}/_collaborator
+      - COLLABORATOR_API_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}/_collaborator
+      - MINIO_ENDPOINT=minio
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+      - MONGO_URL=mongodb://mongodb:27017
+      - TITLE=Huly Self Host
+      - DEFAULT_LANGUAGE=en
+      - LAST_NAME_FIRST=true
+    restart: unless-stopped
+    networks:
+      - internal-services
+      - nginx-public
+
+networks:
+  nginx-public:
+    name: nginx-public
+  internal-services:
+    name: internal-services
+
+volumes:
+  db:
+  letsencrypt:
+  elastic:
+  files:


### PR DESCRIPTION
Hey
Created some simple Nginx config to start Huly on one domain name without need to setup subdomains, CORS and websockets.

- Config is generated through `setup.sh`
- User could choose between ssl (https/wss) and non-ssl configuration
- Websockets are working correctly through Nginx

SSL should be configured separately

If you already have Nginx with certificates manager set up on your host simply add a config and point to exposed port from the docker compose.
For example:

```
server {
    listen 443;
    server_name ${your domain};

   location / {
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;

        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        proxy_pass http://localhost:${EXPOSED_NGINX_PORT};
    }
}
```