### PR TITLE
This PR removes the use of the links directive from the compose.yml file.

### DIFF
--- a/template.compose.yaml
+++ b/template.compose.yaml
@@ -43,9 +43,6 @@ services:
     restart: unless-stopped
   account:
     image: hardcoreeng/account:${HULY_VERSION}
-    links:
-      - mongodb
-      - minio
     ports:
       - 3000:3000
     environment:
@@ -61,9 +58,6 @@ services:
     restart: unless-stopped
   workspace:
     image: hardcoreeng/workspace:${HULY_VERSION}
-    links:
-      - mongodb
-      - minio
     environment:
       - SERVER_SECRET=${HULY_SECRET}
       - MONGO_URL=mongodb://mongodb:27017
@@ -75,12 +69,6 @@ services:
     restart: unless-stopped
   front:
     image: hardcoreeng/front:${HULY_VERSION}
-    links:
-      - mongodb
-      - minio
-      - elastic
-      - collaborator
-      - transactor
     ports:
       - 8087:8080
     environment:
@@ -102,10 +90,6 @@ services:
     restart: unless-stopped
   collaborator:
     image: hardcoreeng/collaborator:${HULY_VERSION}
-    links:
-      - mongodb
-      - minio
-      - transactor
     ports:
       - 3078:3078
     environment:
@@ -117,11 +101,6 @@ services:
     restart: unless-stopped
   transactor:
     image: hardcoreeng/transactor:${HULY_VERSION}
-    links:
-      - mongodb
-      - elastic
-      - minio
-      - account
     ports:
       - 3333:3333
     environment:


### PR DESCRIPTION
### Reasoning
The links directive is no longer necessary as of Docker 1.9 and Docker Compose 1.9, which were released in 2015 and 2016 respectively. Docker's built-in networking now allows containers to communicate with each other using their service names automatically, thanks to internal DNS resolution. This feature simplifies container communication by making it unnecessary to explicitly define links between services in the compose file.

### Changes
Removed links directive from all relevant services in the docker-compose.yml.
Verified that services are able to communicate with each other using their service names over Docker's default bridge network.

### Benefits
Simplifies the docker-compose.yml configuration.
Adheres to modern Docker Compose best practices.
Improves maintainability and readability of the configuration file.

### Testing
All services were tested and confirmed to communicate correctly using their service names without the links directive.