### PR TITLE
Add MongoDB persistent volume claim configuration

### DIFF
--- a/kube/mongodb/mongodb-persistentvolumeclaim.yml
+++ b/kube/mongodb/mongodb-persistentvolumeclaim.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db 
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
This pull request includes the addition of a new PersistentVolumeClaim configuration for MongoDB in the Kubernetes setup. The most important change is the creation of a `PersistentVolumeClaim` resource to allocate storage for the MongoDB database.

Kubernetes configuration updates:

* [`kube/mongodb/mongodb-persistentvolumeclaim.yml`](diffhunk://#diff-c75a68b1cf58c6e163042743e75184a4e656551250deba268febda7c3f5cd8b0R1-R10): Added a new `PersistentVolumeClaim` resource with `ReadWriteOnce` access mode and a storage request of `100Mi` for the MongoDB database.


100Mi is less, I understand but it is just a placeholder.