### PR TITLE
Fixes stuck deployment 

### DIFF
--- a/kube/account/account-deployment.yaml
+++ b/kube/account/account-deployment.yaml
@@ -56,7 +56,10 @@ spec:
                   name: huly-secret
                   key: SERVER_SECRET
             - name: TRANSACTOR_URL
-              value: ws://transactor:3333;ws://localhost:3333
+              valueFrom:
+                configMapKeyRef:
+                  name: huly-config
+                  key: TRANSACTOR_URL
             - name: ENDPOINT_URL
               valueFrom:
                 configMapKeyRef:

--- a/kube/transactor/transactor-ingress.yaml
+++ b/kube/transactor/transactor-ingress.yaml
@@ -3,19 +3,22 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/enable-websocket: "true"
   labels:
     app: transactor
   name: transactor
 spec:
   ingressClassName: nginx
   rules:
-    - host: transactor.huly.example
+    - host: transactor.tributor.in
       http:
         paths:
           - backend:
               service:
                 name: transactor
                 port:
-                  number: 80
+                  number: 3333 # Updated port number to match the service port
             path: /
             pathType: Prefix

--- a/kube/transactor/transactor-service.yaml
+++ b/kube/transactor/transactor-service.yaml
@@ -6,8 +6,9 @@ metadata:
   name: transactor
 spec:
   ports:
-    - port: 80
+    - port: 3333
       protocol: TCP
       targetPort: 3333
   selector:
     app: transactor
+  type: ClusterIP 


### PR DESCRIPTION
This pull request fixes issue #45 Thanks to [muradbozik](https://github.com/muradbozik) for pointing out the solution and [FireflyHacker](https://github.com/FireflyHacker) for confirming the solution.

Environment variable updates:

* [`kube/account/account-deployment.yaml`](diffhunk://#diff-ca5c5a052e6edb9fba40cb14b612c738835caf9cc918b9b259f2a87e0b702070L59-R62): Changed the `TRANSACTOR_URL` environment variable to use a `configMapKeyRef` instead of a hardcoded value.

Ingress settings updates:

* [`kube/transactor/transactor-ingress.yaml`](diffhunk://#diff-6979b6ce9085d94349656043b4668fcba449697dd02ca9a717c901e3ec010758R6-R22): Added annotations to enable WebSocket support and set proxy timeouts. Updated the host and port number to match the service configuration.

Service port configuration:

* [`kube/transactor/transactor-service.yaml`](diffhunk://#diff-dd5b4f7d04c8889af6a77da8d7623ca9c3a3051077d6477c5dc2cfc27c213db2L9-R14): Changed the service port from 80 to 3333 and set the service type to `ClusterIP`.