### PR TITLE
fix: update FRONT_URL in transactor container to value of $SERVER_ADD…

### DIFF
--- a/nginx/template-compose.yaml
+++ b/nginx/template-compose.yaml
@@ -80,7 +80,7 @@ services:
       - METRICS_FILE=metrics.txt
       - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
       - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
+      - FRONT_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}
       - ACCOUNTS_URL=http://account:3000
       - LAST_NAME_FIRST=true
       - UPLOAD_URL=${NGINX_HTTP_SCHEME}://${SERVER_ADDRESS}/files

--- a/traefik/template-compose.yaml
+++ b/traefik/template-compose.yaml
@@ -122,7 +122,7 @@ services:
       - METRICS_FILE=metrics.txt
       - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
       - REKONI_URL=http://rekoni:4004
-      - FRONT_URL=http://localhost:8087
+      - FRONT_URL=https://${SERVER_ADDRESS}
       - ACCOUNTS_URL=http://account:3000
       - LAST_NAME_FIRST=true
     restart: unless-stopped


### PR DESCRIPTION
This bugfix is noticeable when you attempt to create a "Public link" from any document. 

Prior to this bugfix, the URL generated by the UI was hardcoding to `http://localhost:8087/guest/<...>` 
With this bugfix, the URL generated by the UI correctly prints URLs using the value of `$SERVER_ADDRESS`