### PR TITLE
Add kind selfhost example

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,89 @@
+name: ci
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+
+jobs:
+  kind-selfhost:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+        - name: "Checkout repository"
+          uses: actions/checkout@v4
+          with:
+            path: ${{ github.workspace }}/src/github.com/${{ github.repository }}
+
+        - name: "Install kind"
+          run: |
+            [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
+            # For ARM64
+            [ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-arm64
+            chmod +x ./kind
+            sudo mv ./kind /usr/local/bin/kind
+ 
+        - name: "Setup k8s cluster"
+          run: |
+            cat <<EOF | kind create cluster --wait=3m --config=-
+            kind: Cluster
+            apiVersion: kind.x-k8s.io/v1alpha4
+            nodes:
+            - role: control-plane
+              extraPortMappings:
+              - containerPort: 80
+                hostPort: 80
+                protocol: TCP
+              - containerPort: 443
+                hostPort: 443
+                protocol: TCP
+            EOF
+
+        - name: "Print cluster details"
+          run: |
+            kubectl cluster-info
+            kubectl version
+            kubectl get pods -n kube-system
+            echo "current-context:" $(kubectl config current-context)
+            echo "environment-kubeconfig:" ${KUBECONFIG}
+
+
+        - name: "Install nginx ingress controller"
+          run: |
+            kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+            kubectl wait --namespace ingress-nginx \
+              --for=condition=ready pod \
+              --selector=app.kubernetes.io/component=controller \
+              --timeout=90s
+
+        - name: "Huly deploy"
+          working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}/kube
+          run: |
+            echo 127.0.0.1 huly.example | sudo tee -a /etc/hosts
+            echo 127.0.0.1 account.huly.example | sudo tee -a /etc/hosts
+            kubectl apply -R -f .
+            kubectl wait --for=condition=Available deployment/mongodb --timeout 3m
+            kubectl wait --for=condition=Available deployment/transactor --timeout 3m
+            kubectl delete pod -l app=account
+            kubectl wait --for=condition=Available deployment/account --timeout 3m
+        - name: "Check login"
+          run: |
+            token=$(curl -v -H 'Content-Type: application/json' \
+            -d '{"method":"createAccount","params":["user1","1234","user","1"]}' \
+            -X POST \
+            http://account.huly.example/ | jq -r '.result.token')
+
+            curl -v http://account.huly.example/ \
+              -X POST \
+              -d '{"method":"getUserWorkspaces","params":[]}' \
+              -H 'Content-Type: application/json' \
+              -H 'Accept: */*' \
+              -H "Authorization: Bearer $token"
+
+        - name: Cleanup resources
+          if: ${{ success() || failure() || cancelled() }}
+          run: |
+            kubectl describe pods
+            kind delete cluster

--- a/kube/QUICKSTART.md
+++ b/kube/QUICKSTART.md
@@ -1,0 +1,97 @@
+# Quick Start with Kind
+> [!NOTE]
+> kind does not require kubectl, but you will not be able to perform some of the examples in our docs without it. To install kubectl see the upstream kubectl installation docs.
+
+## Install 
+
+**macOS:**
+```bash
+# For Intel Macs
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-darwin-amd64
+# For M1 / ARM Macs
+[ $(uname -m) = arm64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-darwin-arm64
+chmod +x ./kind
+mv ./kind /some-dir-in-your-PATH/kind
+```
+
+**Linux:**
+```bash
+# For AMD64 / x86_64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
+# For ARM64
+[ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-arm64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+```
+
+## Setup cluster with port forwarding 
+
+> [!NOTE]
+> On the host computer, `localhost:80` should be accessible.
+
+```bash
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+```
+
+Deploy the ingress nginx controller:
+```bash
+kubectl apply -f https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml
+```
+
+Wait the nginx controller to be ready:
+```bash
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
+```
+
+Add host entries to be able to work with ingresses from the host machine:
+```bash
+sudo cp -p /etc/hosts /tmp/hosts
+echo "127.0.0.1       huly.example" | sudo tee -a /etc/hosts
+echo "127.0.0.1       account.huly.example" | sudo tee -a /etc/hosts
+```
+
+Deploy Huly with `kubectl`:
+
+```bash
+kubectl apply -R -f .
+```
+
+Wait until the front app is coming up:
+```bash
+kubectl wait --for=condition=Avaiable deployment/front --timeout 3m
+```
+
+Now, launch your web and and (enjoy Huly!)[http://huly.example]!
+
+
+## Cleanup
+
+Restore hosts file:
+```bash
+sudo mv /tmp/hosts /etc/hosts
+```
+
+Cleanup Huly:
+```bash
+kubectl delete -R -f .
+```
+
+Delete kind cluster:
+```bash
+kind delete cluster
+```

--- a/kube/README.md
+++ b/kube/README.md
@@ -2,6 +2,12 @@
 
 This folder contains a sample configuration for Huly Kubernetes deployment.
 
+## Requires
+
+Requires a working kubernetes cluster with min one node. Each node should have min 2 vCPUs and 4GB of RAM.
+
+if you don't have any k8s cluster, consider to use [kind setup](KIND.md).
+
 ## Check and update configuration
 
 Huly deployment configuration is located in [config.yaml](config/config.yaml) and [secret.yaml](config/secret.yaml) files.

--- a/kube/README.md
+++ b/kube/README.md
@@ -6,7 +6,7 @@ This folder contains a sample configuration for Huly Kubernetes deployment.
 
 Requires a working kubernetes cluster with min one node. Each node should have min 2 vCPUs and 4GB of RAM.
 
-if you don't have any k8s cluster, consider to use [kind setup](KIND.md).
+If you don't have any k8s cluster, consider using the [kind setup](QUICKSTART.md).
 
 ## Check and update configuration
 

--- a/kube/account/account-deployment.yaml
+++ b/kube/account/account-deployment.yaml
@@ -42,6 +42,11 @@ spec:
                 configMapKeyRef:
                   name: huly-config
                   key: MONGO_URL
+            - name: MONGO_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: huly-config
+                  key: MONGO_URL
             - name: SERVER_SECRET
               valueFrom:
                 secretKeyRef:

--- a/kube/mongodb/mongodb-deployment.yaml
+++ b/kube/mongodb/mongodb-deployment.yaml
@@ -26,7 +26,6 @@ spec:
           name: mongodb
           ports:
             - containerPort: 27017
-              hostPort: 27017
               protocol: TCP
           volumeMounts:
             - mountPath: /data/db

--- a/kube/mongodb/mongodb-service.yaml
+++ b/kube/mongodb/mongodb-service.yaml
@@ -6,8 +6,8 @@ metadata:
   name: mongodb
 spec:
   ports:
-    - name: "27017"
-      port: 27017
+    - port: 27017
       targetPort: 27017
+      protocol: TCP
   selector:
     app: mongodb


### PR DESCRIPTION
## Motvation
This PR shows how folks can run Huly on their local machines with Kind. Also, this PR adds workflow automation to ensure that the setup from the example works for folks and that new changes don't provide regressions.