### PR TITLE
fix(docker-compose): specify service for transactor HTTP route

### DIFF
--- a/traefik/template-compose.yaml
+++ b/traefik/template-compose.yaml
@@ -146,7 +146,7 @@ services:
       - "traefik.http.routers.transactor.tls=true"
       - "traefik.http.routers.transactor.tls.certresolver=myresolver"
       - "traefik.http.services.transactor.loadbalancer.server.port=3333"
-
+      - "traefik.http.routers.transactor.service=transactor"
       # Strip HTTP prefix
       - "traefik.http.routers.transactor.middlewares=strip-transactor-prefix"
       - "traefik.http.middlewares.strip-transactor-prefix.stripprefix.prefixes=/transactor"


### PR DESCRIPTION
### Summary

This pull request addresses an issue with the Traefik configuration in the Docker Compose setup where the HTTP router for the Transactor service was not specifying its corresponding service, leading to an error message: "Could not define the service name for the router: too many services."

### Changes

- Added the line specifying the `transactor` service for the HTTP route:
  ```yaml
  - "traefik.http.routers.transactor.service=transactor"