### PR TITLE
fix[github#144]: Add public key configuration for web push notifications in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Add these keys into `compose.yaml` in section `services:ses:environment`:
 - PUSH_PRIVATE_KEY=your private key
 ```
 
+As the browser must access the public key for web push notifications setup, you also need to provide it to the front-end service.
+
+Add the public key into `compose.yaml` in section `services:front:environment`:
+
+```yaml
+- PUSH_PUBLIC_KEY=your public key
+```
+
 ## Web Push Notifications
 
 > [!NOTE]


### PR DESCRIPTION
- fixes the documentation for web push setup in versions 0.6.x prior to 0.7.x