### PR TITLE
Update elastic-deployment.yaml

### DIFF
--- a/kube/elastic/elastic-deployment.yaml
+++ b/kube/elastic/elastic-deployment.yaml
@@ -55,7 +55,6 @@ spec:
           name: elastic
           ports:
             - containerPort: 9200
-              hostPort: 9200
               protocol: TCP
           volumeMounts:
             - mountPath: /usr/share/elasticsearch/data


### PR DESCRIPTION
- Removed `hostPort: 9200` from Deployment to prevent direct binding to node public IP