### PR TITLE
[] feat: Customizations for OpenCraft use

### DIFF
--- a/kube/kustomization.yaml
+++ b/kube/kustomization.yaml
@@ -1,0 +1,67 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+patches:
+  # Patch that universally brings all ingresses up to SSL.
+  - path: patches/ssl.yaml
+    target:
+      kind: Ingress
+      annotationSelector: kubernetes.io/ingress.class=nginx
+  # ...However, since we can't use variables in patches, we have
+  # to set some individual ingress overrides manually.
+  #
+  # After all these are done, patches for the domain name must still
+  # be done in OpenTofu modules.
+  - path: patches/transactor-ingress.yaml
+    target:
+      kind: Ingress
+      name: transactor
+  - path: patches/stats-ingress.yaml
+    target:
+      kind: Ingress
+      name: stats
+  - path: patches/rekoni-ingress.yaml
+    target:
+      kind: Ingress
+      name: rekoni
+  - path: patches/front-ingress.yaml
+    target:
+      kind: Ingress
+      name: front
+  - path: patches/collaborator-ingress.yaml
+    target:
+      kind: Ingress
+      name: collaborator
+  - path: patches/account-ingress.yaml
+    target:
+      kind: Ingress
+      name: account
+
+resources:
+- ./fulltext/fulltext-deployment.yaml
+- ./fulltext/fulltext-service.yaml
+- ./workspace/workspace-deployment.yaml
+- ./elastic/elastic-service.yaml
+- ./elastic/elastic-deployment.yaml
+- ./elastic/elastic-persistentvolumeclaim.yaml
+- ./collaborator/collaborator-service.yaml
+- ./collaborator/collaborator-ingress.yaml
+- ./collaborator/collaborator-deployment.yaml
+- ./rekoni/rekoni-service.yaml
+- ./rekoni/rekoni-deployment.yaml
+- ./rekoni/rekoni-ingress.yaml
+- ./account/account-service.yaml
+- ./account/account-ingress.yaml
+- ./account/account-deployment.yaml
+- ./front/front-deployment.yaml
+- ./front/front-service.yaml
+- ./front/front-ingress.yaml
+- ./transactor/transactor-deployment.yaml
+- ./transactor/transactor-service.yaml
+- ./transactor/transactor-ingress.yaml
+- ./stats/stats-deployment.yaml
+- ./stats/stats-service.yaml
+- ./stats/stats-ingress.yaml
+- ./minio/files-persistentvolumeclaim.yaml
+- ./minio/minio-service.yaml
+- ./minio/minio-deployment.yaml

--- a/kube/patches/account-ingress.yaml
+++ b/kube/patches/account-ingress.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/tls/0/secretName
+  value: account-tls

--- a/kube/patches/collaborator-ingress.yaml
+++ b/kube/patches/collaborator-ingress.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/tls/0/secretName
+  value: collaborator-tls

--- a/kube/patches/front-ingress.yaml
+++ b/kube/patches/front-ingress.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/tls/0/secretName
+  value: front-tls

--- a/kube/patches/rekoni-ingress.yaml
+++ b/kube/patches/rekoni-ingress.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/tls/0/secretName
+  value: rekoni-tls

--- a/kube/patches/ssl.yaml
+++ b/kube/patches/ssl.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+  name: not-relevant
+spec:
+  tls:
+    - hosts:
+        - tbd.in.tofu
+      secretName: must-be-replaced

--- a/kube/patches/stats-ingress.yaml
+++ b/kube/patches/stats-ingress.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/tls/0/secretName
+  value: stats-tls

--- a/kube/patches/transactor-ingress.yaml
+++ b/kube/patches/transactor-ingress.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/tls/0/secretName
+  value: transactor-tls


### PR DESCRIPTION
This PR adds a Kustomization file and associated patches to enable deployment on OpenCraft's infrastructure. It omits specific unneeded services and manifests while also providing patches for services which need to be brought up to standards (such as adding SSL support through LetsEncrypt.)

Some data is not covered by these patches. For instance, the domain names of the services are controlled via OpenTofu resource definitions, which include patches to override these values. These are included in [this MR](https://gitlab.com/opencraft/ops/infrastructure/-/merge_requests/234).

**JIRA tickets**: https://tasks.opencraft.com/browse/SE-6477

**Sandbox URL**: https://huly.opencraft.com/

**Testing instructions**:

1. TBD

**Author notes and concerns**:

I'm making this MR against master at present, under the expectation that we would deploy from there and then rebase it periodically with upstream. We could, however, select a different branch to use as the deployment base. If we did so, we'd need an obvious way for someone to know what that branch was. We could either promote a different branch to be the main branch (I haven't looked into how to change which branch is the default branch for an existing repo, but it seems that *should* be possible.)

Either way, though, it looks like we're expected, via the ArgoCD gitops workflow, to periodically rebase against whatever upstream provides.