### PR TITLE
SELFH-195: Fix migration v7

### DIFF
--- a/.huly.nginx
+++ b/.huly.nginx
@@ -91,14 +91,4 @@ server {
         rewrite ^/_stats(/.*)$ $1 break;
         proxy_pass http://stats:4900/;
     }
-
-    location /_datalake {
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        rewrite ^/_datalake(/.*)$ $1 break;
-        proxy_pass http://datalake:4030/;
-    }
 }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -53,7 +53,7 @@ Migration Steps (command examples shown for Docker on macOS):
     -e DB_URL="${CR_DB_URL}" \
     -e QUEUE_CONFIG="redpanda:9092" \
     -v ./backup-all:/backup \
-    -it hardcoreeng/tool:s0.7.213 \
+    -it hardcoreeng/tool:s0.7.228 \
     -- bundle.js restore-from-v6-all /backup
 ```
 

--- a/compose.yml
+++ b/compose.yml
@@ -94,7 +94,7 @@ services:
       - SERVER_PORT=3333
       - SERVER_SECRET=${SECRET}
       - DB_URL=${CR_DB_URL}
-      - STORAGE_CONFIG=datalake|http://datalake:4030
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
       - FRONT_URL=http://localhost:8087
       - ACCOUNTS_URL=http://account:3000
       - FULLTEXT_URL=http://fulltext:4700
@@ -110,7 +110,7 @@ services:
       - SECRET=${SECRET}
       - ACCOUNTS_URL=http://account:3000
       - STATS_URL=http://stats:4900
-      - STORAGE_CONFIG=datalake|http://datalake:4030
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
     restart: unless-stopped
 
   account:
@@ -120,7 +120,7 @@ services:
       - SERVER_SECRET=${SECRET}
       - DB_URL=${CR_DB_URL}
       - TRANSACTOR_URL=ws://transactor:3333;ws${SECURE:+s}://${HOST_ADDRESS}/_transactor
-      - STORAGE_CONFIG=datalake|http://datalake:4030
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
       - FRONT_URL=http${SECURE:+s}://${HOST_ADDRESS}
       - STATS_URL=http${SECURE:+s}://${HOST_ADDRESS}/stats
       - MODEL_ENABLED=*
@@ -135,7 +135,7 @@ services:
       - SERVER_SECRET=${SECRET}
       - DB_URL=${CR_DB_URL}
       - TRANSACTOR_URL=ws://transactor:3333;ws${SECURE:+s}://${HOST_ADDRESS}/_transactor
-      - STORAGE_CONFIG=datalake|http://datalake:4030
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
       - MODEL_ENABLED=*
       - ACCOUNTS_URL=http://account:3000
       - STATS_URL=http://stats:4900
@@ -155,12 +155,10 @@ services:
       - GMAIL_URL=http${SECURE:+s}://${HOST_ADDRESS}/_gmail
       - TELEGRAM_URL=http${SECURE:+s}://${HOST_ADDRESS}/_telegram
       - STATS_URL=http${SECURE:+s}://${HOST_ADDRESS}/_stats
-      - FILES_URL=http${SECURE:+s}://${HOST_ADDRESS}/_datalake/blob/:workspace/:blobId/:filename
-      - UPLOAD_URL=http${SECURE:+s}://${HOST_ADDRESS}/_datalake/upload/form-data/:workspace
-      - PREVIEW_CONFIG=image|http${SECURE:+s}://${HOST_ADDRESS}/_datalake/image/fit=cover,width=:width,height=:height,dpr=:dpr/:workspace/:blobId;video|http${SECURE:+s}://${HOST_ADDRESS}/_datalake/meta/:workspace/:blobId
+      - UPLOAD_URL=/files
       - ELASTIC_URL=http://elastic:9200
       - COLLABORATOR_URL=ws${SECURE:+s}://${HOST_ADDRESS}/_collaborator
-      - STORAGE_CONFIG=datalake|http://datalake:4030
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
       - TITLE=${TITLE:-Huly Self Host}
       - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}
       - LAST_NAME_FIRST=${LAST_NAME_FIRST:-true}
@@ -174,7 +172,7 @@ services:
       - DB_URL=${CR_DB_URL}
       - FULLTEXT_DB_URL=http://elastic:9200
       - ELASTIC_INDEX_NAME=huly_storage_index
-      - STORAGE_CONFIG=datalake|http://datalake:4030
+      - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
       - REKONI_URL=http://rekoni:4004
       - ACCOUNTS_URL=http://account:3000
       - STATS_URL=http://stats:4900
@@ -186,27 +184,6 @@ services:
     environment:
       - PORT=4900
       - SERVER_SECRET=${SECRET}
-    restart: unless-stopped
-
-  datalake:
-    image: hardcoreeng/datalake:${HULY_VERSION}
-    depends_on:
-      minio:
-        condition: service_healthy
-      cockroach:
-        condition: service_started
-      stats:
-        condition: service_started
-      account:
-        condition: service_started
-    environment:
-      - PORT=4030
-      - SECRET=${SECRET}
-      - ACCOUNTS_URL=http://account:3000
-      - STATS_URL=http://stats:4900
-      - DB_URL=${CR_DB_URL}
-      - BUCKETS=huly,eu|http://minio:9000?accessKey=minioadmin&secretKey=minioadmin
-      - QUEUE_CONFIG=redpanda:9092
     restart: unless-stopped
 volumes:
   # These named volumes are used when custom volume paths are not specified


### PR DESCRIPTION
* Reverts Datalake in Docker setup
* Uses new tool version to generate UUID for workspaces where missing

Related to: https://front.hc.engineering/workbench/platform/tracker/SELFH-195
Closes https://github.com/hcengineering/huly-selfhost/issues/196