### PR TITLE
SELFH-199: restore identity providers social ids when migrating to v7

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -63,7 +63,7 @@ Migration Steps (command examples shown for Docker on macOS):
     -e DB_URL="${CR_DB_URL}" \
     -e QUEUE_CONFIG="redpanda:9092" \
     -v ./backup-all:/backup \
-    -it hardcoreeng/tool:s0.7.228 \
+    -it hardcoreeng/tool:s0.7.251 \
     -- bundle.js restore-from-v6-all /backup
 ```
 


### PR DESCRIPTION
Related to: https://front.hc.engineering/workbench/platform/tracker/SELFH-199
Closes https://github.com/hcengineering/huly-selfhost/issues/200