### PR TITLE
Make clear that LIVEKIT_WS expects URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,11 +419,13 @@ self-hosted Huly, perform the following steps:
       front:
         ...
         environment:
-          - LIVEKIT_WS=ws${SECURE:+s}://<LIVEKIT_HOST>
+          - LIVEKIT_WS=<LIVEKIT_HOST>
         ...
     ```
 
 4. Uncomment love section in `.huly.nginx` file and reload nginx
+
+Note that the `LIVEKIT_HOST` should include the protocol (`wss://` by default if using livekit cloud).
 
 ## Print Service
 


### PR DESCRIPTION
In the love environment variables section it says

```
LIVEKIT_HOST=<LIVEKIT_HOST>
```

which wants the domain.

```
LIVEKIT_WS=<LIVEKIT_HOST>
```

In the front service wants a URL but the placeholder implies it's also the domain