### PR TITLE
refactor: simplify - docker compose autogenerates container names

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -39,7 +39,6 @@ services:
       - --mode dev-container
       - --smp 1
       - --default-log-level=info
-    container_name: redpanda
     volumes:
       - ${VOLUME_REDPANDA_PATH:-redpanda}:/var/lib/redpanda/data
     environment:
@@ -90,7 +89,6 @@ services:
 
   # mongodb:
   #   image: mongo:7-jammy
-  #   container_name: mongodb
   #   restart: unless-stopped
   #   volumes:
   #     - ${VOLUME_MONGO_PATH:-mongodb}:/data/db
@@ -100,7 +98,6 @@ services:
 
   # redis:
   #   image: redis:7-alpine
-  #   container_name: redis
   #   command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
   #   restart: unless-stopped
   #   networks:
@@ -109,7 +106,6 @@ services:
 
   # hulypulse:
   #   image: hardcoreeng/service_hulypulse:${HULY_PULSE_VERSION:-0.1.29}
-  #   container_name: hulypulse
   #   ports:
   #     - 8099:8099
   #   environment:


### PR DESCRIPTION
also, this makes it easier to identify which stack a container belongs to in docker ps -a when you run multiple docker compose stacks on the same host