### PR TITLE
fix(helm): pass GitHub App env vars to front for OAuth and installation flows

### DIFF
--- a/helm/huly/templates/front/deployment.yaml
+++ b/helm/huly/templates/front/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             {{- include "huly.envConfig" (dict "name" "LOVE_ENDPOINT" "key" "LOVE_ENDPOINT" "root" .) | nindent 12 }}
             {{- if .Values.githubIntegration.enabled }}
             {{- include "huly.envConfig" (dict "name" "GITHUB_URL" "key" "GITHUB_URL" "root" .) | nindent 12 }}
+            {{- include "huly.envSecret" (dict "name" "GITHUB_CLIENTID" "key" "GITHUB_APP_CLIENT_ID" "root" .) | nindent 12 }}
+            - name: GITHUB_APP
+              value: {{ .Values.githubIntegration.appSlug | quote }}
             {{- end }}
             {{- if .Values.aibot.enabled }}
             {{- include "huly.envConfig" (dict "name" "AI_URL" "key" "AI_URL" "root" .) | nindent 12 }}

--- a/helm/huly/values.yaml
+++ b/helm/huly/values.yaml
@@ -236,6 +236,8 @@ githubIntegration:
   replicas: 1
   # Bot name shown on GitHub (must match the GitHub App's slug + [bot])
   botName: ""
+  # GitHub App slug (from the app URL: github.com/apps/<slug>)
+  appSlug: ""
   # GitHub App credentials (stored in the shared secret)
   appId: ""
   clientId: ""


### PR DESCRIPTION
## Summary

Follow-up to #280. The GitHub integration (`githubIntegration.enabled=true`) is broken without two env vars on the front service:

- **`GITHUB_CLIENTID`** — the front builds the OAuth authorize URL client-side. Without it, `client_id=` is empty → GitHub returns 404.
- **`GITHUB_APP`** — the front builds the GitHub App installation URL. Without it, the URL becomes `/apps//installations/new` → 404.

## Changes

- `templates/front/deployment.yaml`: add `GITHUB_CLIENTID` (from secret) and `GITHUB_APP` (from values) when `githubIntegration.enabled`
- `values.yaml`: add `appSlug` field to `githubIntegration`

## Test plan

- [ ] Enable `githubIntegration` with valid GitHub App credentials
- [ ] Click "Connect" on GitHub integration → OAuth redirect includes `client_id=<value>`
- [ ] Click "Install Github App" → redirects to `github.com/apps/<slug>/installations/new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)