### PR TITLE
docs: fix broken huly_v7.conf link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ cd huly-selfhost
 ./setup.sh
 ```
 
-This will generate a [huly_v7.conf](./huly_v7.conf) file with your chosen values and create your nginx config.
+This will generate a `huly_v7.conf` file with your chosen values and create your nginx config.
 
 To add the generated configuration to your Nginx setup, run the following:
 


### PR DESCRIPTION
## Summary

Removes the broken README link to `huly_v7.conf` and keeps the generated filename as plain code text instead.

## Context

The setup script generates `huly_v7.conf` locally, but that file is not committed in the repository. Linking to it in the README produces a broken GitHub link.

## Issue

Fixes #301

## Changes

- replace the broken Markdown link with plain code formatting for `huly_v7.conf`

## Testing

Ran:

```bash
git diff --check
```

Result: PASS. The README change is clean and the generated filename still matches `setup.sh`.