### PR TITLE
fix: use dynamic HOST_ADDRESS for transactor FRONT_URL

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -145,7 +145,7 @@ services:
       - SERVER_SECRET=${SECRET}
       - DB_URL=${CR_DB_URL}
       - STORAGE_CONFIG=minio|minio?accessKey=minioadmin&secretKey=minioadmin
-      - FRONT_URL=http://localhost:8087
+      - FRONT_URL=http${SECURE:+s}://${HOST_ADDRESS}
       - ACCOUNTS_URL=http://account:3000
       - FULLTEXT_URL=http://fulltext:4700
       - STATS_URL=http://stats:4900

--- a/nginx.sh
+++ b/nginx.sh
@@ -24,8 +24,11 @@ else
     fi
 fi
 
+# Strip port from HOST_ADDRESS for server_name (nginx server_name doesn't include port)
+HOST_DOMAIN=$(echo "${HOST_ADDRESS}" | sed 's/:[0-9]*$//')
+
 # Update server_name and proxy_pass using sed
-sed -i.bak "s|server_name .*;|server_name ${HOST_ADDRESS};|" ./nginx.conf
+sed -i.bak "s|server_name .*;|server_name ${HOST_DOMAIN};|" ./nginx.conf
 sed -i.bak "s|proxy_pass .*;|proxy_pass http://${HTTP_BIND:-127.0.0.1}:${HTTP_PORT};|" ./nginx.conf
 
 # Update listen directive to either port 80 or 443, while preserving IP address


### PR DESCRIPTION
Fixes issue where signing up from a remote laptop fails because the transactor service has a hardcoded FRONT_URL=http://localhost:8087.

The browser receives redirects pointing to localhost instead of the actual server Tailscale IP.

**Changes:**

- compose.yml: Changed transactor FRONT_URL from hardcoded localhost to http${SECURE:+s}://${HOST_ADDRESS} (matching all other services)
- nginx.sh: Fix server_name generation to strip port from HOST_ADDRESS (nginx server_name doesn't support port notation)

PLY-75